### PR TITLE
advanced usage fixes

### DIFF
--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -314,7 +314,7 @@ The call is otherwise identical except instead of `Get`, it's `GetAsync`. Simila
 
 ```c++
 AsyncResponse fr = cpr::GetAsync(cpr::Url{"http://www.httpbin.org/get"});
-fr.wait() // This waits until the request is complete
+fr.wait(); // This waits until the request is complete
 cpr::Response r = fr.get(); // Since the request is complete, this returns immediately
 std::cout << r.text << std::endl;
 ```

--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -313,7 +313,7 @@ std::cout << r.text << std::endl;
 The call is otherwise identical except instead of `Get`, it's `GetAsync`. Similarly for POST requests, you would call `PostAsync`. The return value of an asynchronous call is actually a `std::future<Response>`:
 
 ```c++
-AsyncResponse fr = cpr::GetAsync(cpr::Url{"http://www.httpbin.org/get"});
+cpr::AsyncResponse fr = cpr::GetAsync(cpr::Url{"http://www.httpbin.org/get"});
 fr.wait(); // This waits until the request is complete
 cpr::Response r = fr.get(); // Since the request is complete, this returns immediately
 std::cout << r.text << std::endl;


### PR DESCRIPTION
Changes code to not assume we're using the cpr namespace, and introduces a previously missed semicolon.