### PR TITLE
Add instructions for building with Bazel

### DIFF
--- a/index.md
+++ b/index.md
@@ -88,6 +88,10 @@ That should do it!
 There's no need to handle `libcurl` yourself. All dependencies are taken care of for you.  
 All of this can be found in an example [**here**](https://github.com/libcpr/example-cmake-fetch-content).
 
+### Bazel
+
+Please refer to [hedronvision/bazel-make-cc-https-easy](https://github.com/hedronvision/bazel-make-cc-https-easy).
+
 ### Packages for Linux Distributions
 
 Alternatively, you may install a package specific to your Linux distribution. Since so few distributions currently have a package for cpr, most users will not be able to run your program with this approach.


### PR DESCRIPTION
Hi, @COM8!

I was writing some more code with your wonderful library and referring to the docs, when I noticed that the Bazel instructions we'd added to the main repo in https://github.com/libcpr/cpr/pull/846 weren't reflected over there. This PR fixes that. Sorry about not doing it earlier; had wrongly assumed they were synced. 

Thanks again for working to give such a great gift to the world! I so appreciate getting to use it every day.
Chris