### PR TITLE
Fix small discrepancy in docs

### DIFF
--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -532,7 +532,7 @@ This includes empty lines and the `HTTP` status line.  `\r\n` endings are preser
 The callback signature looks like this.
 
 ```c++
-  bool headerCallback(std::string_view data, intptr_t userdata);
+  bool headerCallback(std::string_view & data, intptr_t userdata);
 ```
 
 Provide the callback with the HeaderCallback options object.  Only one header callback may be set.
@@ -547,7 +547,7 @@ You could buffer data in your own way, or write every chunk immediately out to s
 The callback signature looks like this.
 
 ```c++
-  bool writeCallback(std::string_view data, intptr_t userdata);
+  bool writeCallback(std::string_view & data, intptr_t userdata);
 ```
 
 Provide the callback with the WriteCallback options object.  Only one write callback may be set.

--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -532,7 +532,7 @@ This includes empty lines and the `HTTP` status line.  `\r\n` endings are preser
 The callback signature looks like this.
 
 ```c++
-  bool headerCallback(std::string_view & data, intptr_t userdata);
+  bool headerCallback(const std::string_view & data, intptr_t userdata);
 ```
 
 Provide the callback with the HeaderCallback options object.  Only one header callback may be set.

--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -532,7 +532,7 @@ This includes empty lines and the `HTTP` status line.  `\r\n` endings are preser
 The callback signature looks like this.
 
 ```c++
-  bool headerCallback(std::string_view & data, intptr_t userdata);
+  bool headerCallback(std::string_view data, intptr_t userdata);
 ```
 
 Provide the callback with the HeaderCallback options object.  Only one header callback may be set.
@@ -547,7 +547,7 @@ You could buffer data in your own way, or write every chunk immediately out to s
 The callback signature looks like this.
 
 ```c++
-  bool writeCallback(std::string_view & data, intptr_t userdata);
+  bool writeCallback(std::string_view data, intptr_t userdata);
 ```
 
 Provide the callback with the WriteCallback options object.  Only one write callback may be set.

--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -532,7 +532,7 @@ This includes empty lines and the `HTTP` status line.  `\r\n` endings are preser
 The callback signature looks like this.
 
 ```c++
-  bool headerCallback(std::string data, intptr_t userdata);
+  bool headerCallback(std::string_view & data, intptr_t userdata);
 ```
 
 Provide the callback with the HeaderCallback options object.  Only one header callback may be set.
@@ -547,7 +547,7 @@ You could buffer data in your own way, or write every chunk immediately out to s
 The callback signature looks like this.
 
 ```c++
-  bool writeCallback(std::string data, intptr_t userdata);
+  bool writeCallback(std::string_view & data, intptr_t userdata);
 ```
 
 Provide the callback with the WriteCallback options object.  Only one write callback may be set.

--- a/advanced-usage.md
+++ b/advanced-usage.md
@@ -547,7 +547,7 @@ You could buffer data in your own way, or write every chunk immediately out to s
 The callback signature looks like this.
 
 ```c++
-  bool writeCallback(std::string_view & data, intptr_t userdata);
+  bool writeCallback(const std::string_view & data, intptr_t userdata);
 ```
 
 Provide the callback with the WriteCallback options object.  Only one write callback may be set.


### PR DESCRIPTION
There was a discrepancy where the docs said a callback should have one signature but the code said otherwise, leading to errors. This commit fixes that discrepancy.